### PR TITLE
Add second URL for git-imerge

### DIFF
--- a/docs/01-index.md
+++ b/docs/01-index.md
@@ -43,11 +43,12 @@ Command line helper for GitHub
 * http://defunkt.io/hub/hub.1.html
 
 
-## imerge
+## git-imerge
 
 Incremental merge for git
 
-https://github.com/mhagger/git-imerge
+* https://github.com/mhagger/git-imerge
+* http://softwareswirl.blogspot.de/search/label/git-imerge
 
 
 ## Git Training Materials by GitHub


### PR DESCRIPTION
The second links to my blog articles about the subject, including detailed (probably much _too_ detailed) explanations.
